### PR TITLE
fix: data blocks causing issues with hyphenated strings

### DIFF
--- a/internal/terraformlinter/terraform_linter.go
+++ b/internal/terraformlinter/terraform_linter.go
@@ -44,6 +44,7 @@ const (
 	tokenTypeLocals   = "locals"
 	tokenTypeImport   = "import"
 	tokenTypeMoved    = "moved"
+	tokenTypeData     = "data"
 )
 
 // List of valid extensions that can be linted.
@@ -295,7 +296,8 @@ func (l *Linter) findViolations(content []byte, path string) error {
 				contents == tokenTypeVariable ||
 				contents == tokenTypeLocals ||
 				contents == tokenTypeImport ||
-				contents == tokenTypeMoved) {
+				contents == tokenTypeMoved ||
+				contents == tokenTypeData) {
 			inBlock = true
 			start = idx
 			depth = 0

--- a/internal/terraformlinter/terraform_linter_test.go
+++ b/internal/terraformlinter/terraform_linter_test.go
@@ -600,6 +600,20 @@ module "mymodule" {
 }
 			`,
 		},
+		// https://github.com/abcxyz/terraform-linter/issues/30
+		{
+			name: "bug_repro_hyphen_in_string_value - no support for data blocks",
+			content: `
+		data "google_project" "gad" {
+		  project_id = module.imports.data.action_dispatcher.components.webhook.stage.project_id
+		}
+
+		module "common" {
+		  domains = ["action-dispatcher-stage.ghss.joonix.net"]
+		}
+		        `,
+			expect: ``,
+		},
 	}
 
 	for _, tc := range cases {
@@ -623,7 +637,7 @@ module "mymodule" {
 			}
 
 			if got, want := strings.TrimSpace(buf.String()), strings.TrimSpace(tc.expect); got != want {
-				t.Errorf("expected\n\n%s\n\nto be\n\n%s", got, want)
+				t.Errorf("expected: \n\n%s\n\ngot:\n\n%s", want, got)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #30 

The `data` terraform token was not being treated as a top level object because we didn't have specific rules we wanted to enforce in those blocks.

This led to a weird scenario that caused all subsequent strings following a data block to be check against TF001, no hyphens in resource names, which led to false positive errors.

Blocks like

```		
data "google_project" "gad" {
  project_id = module.imports.data.action_dispatcher.components.webhook.stage.project_id
}

module "common" {
  domains = ["action-dispatcher-stage.ghss.joonix.net"]
}
```

Would error on `domains = ["action-dispatcher-stage.ghss.joonix.net"]` which is valid terraform and should not have been flagged.